### PR TITLE
Fix CV page text visibility in dark theme - Closes #3

### DIFF
--- a/assets/css/cv-layout.css
+++ b/assets/css/cv-layout.css
@@ -3,7 +3,7 @@
   padding: 1rem 0;
   text-align: center;
   margin-bottom: 2rem;
-  border-bottom: 1px solid #f2f2f2;
+  border-bottom: 1px solid var(--global-border-color, #f2f2f2);
 }
 
 .cv-header-nav .home-button {
@@ -33,7 +33,7 @@
   margin-top: 2rem;
   text-align: center;
   padding: 1rem;
-  border-top: 1px solid #f2f2f2;
+  border-top: 1px solid var(--global-border-color, #f2f2f2);
 }
 
 .cv-download-links a {

--- a/assets/css/cv-style.css
+++ b/assets/css/cv-style.css
@@ -3,7 +3,7 @@
   max-width: 1000px;
   margin: 0 auto;
   font-family: 'Roboto', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  color: #333;
+  color: var(--global-text-color, #333);
   line-height: 1.6;
 }
 
@@ -69,7 +69,7 @@
 }
 
 .cv-section h2 i {
-  color: #666;
+  color: var(--global-text-color-light, #666);
 }
 
 /* Item Styles */
@@ -89,11 +89,11 @@
 }
 
 .cv-item-date {
-  color: #666;
+  color: var(--global-text-color-light, #666);
 }
 
 .cv-item-subtitle {
-  color: #666;
+  color: var(--global-text-color-light, #666);
   margin-bottom: 0.5rem;
 }
 
@@ -128,7 +128,7 @@
 
 .cv-skill-category h3 {
   margin-bottom: 0.5rem;
-  color: #333;
+  color: var(--global-text-color, #333);
 }
 
 .cv-skill-keywords {
@@ -177,7 +177,7 @@
 }
 
 .cv-language-fluency {
-  color: #666;
+  color: var(--global-text-color-light, #666);
   font-size: 0.9rem;
 }
 
@@ -190,7 +190,7 @@
 
 .cv-interest h3 {
   margin-bottom: 0.5rem;
-  color: #333;
+  color: var(--global-text-color, #333);
 }
 
 .cv-interest-keywords {
@@ -209,7 +209,7 @@
 /* References Styles */
 .cv-references {
   font-style: italic;
-  color: #666;
+  color: var(--global-text-color-light, #666);
 }
 
 /* Print Styles */


### PR DESCRIPTION
   Fixes #3 - CV page text visibility in dark theme
   
   Updated CV CSS files to use CSS variables instead of hardcoded colors:
   - Changed text colors to use --global-text-color and --global-text-color-light
   - Updated border colors to use --global-border-color
   - This ensures proper contrast in both light and dark themes