### PR TITLE
Add explicit dark theme styles to CV page - additional fix for #3

### DIFF
--- a/_pages/cv-json.md
+++ b/_pages/cv-json.md
@@ -25,6 +25,29 @@ redirect_from:
       width: 70%;
     }
   }
+
+  /* Dark theme support for CV page */
+  html[data-theme="dark"] .cv-container {
+    color: var(--global-text-color);
+  }
+
+  html[data-theme="dark"] .cv-item-date,
+  html[data-theme="dark"] .cv-item-subtitle,
+  html[data-theme="dark"] .cv-section h2 i,
+  html[data-theme="dark"] .cv-language-fluency,
+  html[data-theme="dark"] .cv-references {
+    color: var(--global-text-color-light);
+  }
+
+  html[data-theme="dark"] .cv-skill-category h3,
+  html[data-theme="dark"] .cv-interest h3 {
+    color: var(--global-text-color);
+  }
+
+  html[data-theme="dark"] .cv-header-nav,
+  html[data-theme="dark"] .cv-download-links {
+    border-color: var(--global-border-color);
+  }
 </style>
 
 {% include cv-template.html %}


### PR DESCRIPTION
   Fixes #3 - CV page text visibility in dark theme
   
   Updated CV CSS files to use CSS variables instead of hardcoded colors:
   - Changed text colors to use --global-text-color and --global-text-color-light
   - Updated border colors to use --global-border-color
   - Added explicit dark theme styles to CV page for better specificity
   - This ensures proper contrast in both light and dark themes