### PR TITLE
Fix category filtering for projects with multiple categories

### DIFF
--- a/src/pages/tableau.astro
+++ b/src/pages/tableau.astro
@@ -336,7 +336,7 @@ import '../styles/global.css';
           // Filter projects
           projects.forEach(project => {
             const category = project.getAttribute('data-category');
-            if (filter === 'all' || category === filter) {
+            if (filter === 'all' || category.includes(filter)) {
               project.classList.remove('hidden');
             } else {
               project.classList.add('hidden');


### PR DESCRIPTION
- Change filter logic from exact match (===) to includes() method
- Enables Stats+Stories project to appear in both 'pop-culture' and 'exploratory' filters
- All category filters now work correctly for multi-category projects

Fixes #15